### PR TITLE
adds a project issue syncer to the template

### DIFF
--- a/.github/workflows/sync-issues-to-project-board.yaml
+++ b/.github/workflows/sync-issues-to-project-board.yaml
@@ -1,0 +1,16 @@
+name: Add new and labeled issues to Images project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/chainguard-dev/projects/22
+          github-token: ${{ secrets.PROJECT_WRITER }}


### PR DESCRIPTION
This will guarantee all new image repos will sync their issues to our images project board.

Signed-off-by: Patrick Flynn <patrick@chainguard.dev>