### PR TITLE
have example use alpine packages so they're multi-arch

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -1,11 +1,10 @@
 contents:
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   repositories:
-    - https://packages.wolfi.dev/os
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
   packages:
+    - alpine-baselayout-data
     - ca-certificates-bundle
-    - wolfi-base
+    - tzdata
 
 accounts:
   groups:


### PR DESCRIPTION
Fixes failure like this: https://github.com/chainguard-images/template/actions/runs/3154576957/jobs/5132324708